### PR TITLE
Navigation fixes

### DIFF
--- a/src/components/View/CardView/CardButton.tsx
+++ b/src/components/View/CardView/CardButton.tsx
@@ -1,6 +1,9 @@
 import { Link } from 'react-router-dom';
 import { DynamicObject } from '../../../types/DynamicObject';
-import { resolveCardBindings } from '../../../utils/utils';
+import {
+    resolveCardBindings,
+    resolveLinkTargetView,
+} from '../../../utils/utils';
 
 export const CardButton = ({
     element,
@@ -16,12 +19,14 @@ export const CardButton = ({
     const entity = children?.[0].attributes.Entity;
     const childrenId = children?.[0].attributes.Id;
 
+    const linkTargetView = resolveLinkTargetView(entity, elementName);
+
     switch (elementName) {
         case 'NavigateToRegisterCommand':
             return (
                 <Link
                     className="flex flex-col lg:flex-row lg:gap-32 font-semibold text-ad-primary hover:text-ad-primary-hover"
-                    to={`/view/${entity}RegisterView`}
+                    to={`/view/${linkTargetView}`}
                     id={element.attributes.Identifier}
                 >
                     {element.attributes.Text}
@@ -43,7 +48,7 @@ export const CardButton = ({
                 return (
                     <Link
                         className="flex-1 max-h-12 px-2 py-1 font-semibold text-ad-primary hover:text-ad-primary-hover"
-                        to={`/view/${entity}CardView/${cardIdToNavigate?.toString()}`}
+                        to={`/view/${linkTargetView}/${cardIdToNavigate?.toString()}`}
                         id={element.attributes.Identifier}
                     >
                         {binding?.toString()}
@@ -61,7 +66,7 @@ export const CardButton = ({
                     {cardIdToNavigate ? (
                         <Link
                             className="flex-1 max-h-12 px-2 py-1 font-semibold text-ad-primary hover:text-ad-primary-hover"
-                            to={`/view/${entity}CardView/${cardIdToNavigate?.toString()}`}
+                            to={`/view/${linkTargetView}/${cardIdToNavigate?.toString()}`}
                             id={element.attributes.Identifier}
                         >
                             {binding?.toString()}

--- a/src/components/View/RegisterView.tsx
+++ b/src/components/View/RegisterView.tsx
@@ -103,7 +103,7 @@ export const RegisterView = ({ view }: DataProps) => {
     const orderBy: OrderBy[] = parseOrderOptions(OrderOptionsEl, EntitySchema);
     !selectedOrderOption && setSelectedOrderOption(orderBy[0] || null);
 
-    const { columns, bindings } = parseRegisterMetaView(view);
+    const tableData = parseRegisterMetaView(view);
 
     /**
      * Event handling
@@ -182,9 +182,8 @@ export const RegisterView = ({ view }: DataProps) => {
                         handleSelectOrderBy={handleSelectOrderBy}
                     />
                     <RegisterTable
-                        columns={columns}
+                        tableData={tableData}
                         entities={fetchedEntities}
-                        bindings={bindings}
                         entityType={EntityType}
                         contextMenu={TableRowContextMenuItemsFormatted}
                     />

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -4,6 +4,7 @@ import {
     getEntitySchema,
     getEntityToString,
     getFormattedText,
+    getMetaViews,
 } from '../temp/SchemaUtils';
 import Handlebars from 'handlebars';
 import { DtoEntity } from '../types/DtoEntity';
@@ -305,4 +306,51 @@ export const getUserLanguage = () => {
     else lang = navigator.language.split('-')[0];
 
     return lang in SUPPORTED_LANGUAGES ? lang : DEFAULT_LANGUAGE;
+};
+
+/**
+ * A function for resolving navigation link target view name based on the entity name and command type.
+ * View name is resolved by iterating the whole metaviewList for a view that includes both
+ * the entity name and a specific command target view type.
+ *
+ * @param {string} entityName target view entity
+ * @param {string} command "NavigateToCardCommand" | "NavigateToRegisterCommand" | "CommandReference"
+ * @returns {string} The resolved target view name. If no matching view is found, the original entity name is returned.
+ *
+ * @example
+ *  // finds and returns a target view "Economy:DiscountContractCardView"
+ *  resolveLinkTargetView("DiscoundContract", "NavigateToCardCommand")
+ */
+export const resolveLinkTargetView = (
+    entityName: string,
+    command: string,
+): string => {
+    const xmlMetaViewList = getMetaViews();
+    const xmlParser = new DOMParser();
+
+    const commandTargetViewTypes: { [key: string]: string } = {
+        NavigateToCardCommand: 'CardView',
+        NavigateToRegisterCommand: 'RegisterView',
+        CommandReference: '',
+    };
+
+    let targetViewName;
+    // Iterate through the xmlMetaViewList and check if there is a metaview item with name
+    // that includes both entity name and commandTargetViewType.
+    for (const metaView of xmlMetaViewList) {
+        const doc = xmlParser.parseFromString(
+            metaView.XML,
+            'text/xml',
+        ).documentElement;
+        const name = doc.getAttribute('Name');
+
+        if (
+            name?.includes(entityName) &&
+            name?.includes(commandTargetViewTypes?.[command])
+        ) {
+            targetViewName = name;
+            break;
+        }
+    }
+    return targetViewName || entityName;
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -309,12 +309,14 @@ export const getUserLanguage = () => {
 };
 
 /**
- * A function for resolving navigation link target view name based on the entity name and command type.
+ * A function for resolving navigation link target view name based on the entity name and/or command type.
  * View name is resolved by iterating the whole metaviewList for a view that includes both
  * the entity name and a specific command target view type.
+ * In some cases the target view can be resolved directly from the commandEntity (NavigateCommand)
  *
  * @param {string} entityName target view entity
  * @param {string} command "NavigateToCardCommand" | "NavigateToRegisterCommand" | "CommandReference"
+ * @param {DynamicObject | undefined} commandEntity object
  * @returns {string} The resolved target view name. If no matching view is found, the original entity name is returned.
  *
  * @example
@@ -324,7 +326,13 @@ export const getUserLanguage = () => {
 export const resolveLinkTargetView = (
     entityName: string,
     command: string,
+    commandEntity?: DynamicObject,
 ): string => {
+    //If command is "navigateCommand", extract the targetView directly from command entity
+    if (command === 'NavigateCommand' && commandEntity) {
+        return commandEntity?.getAttribute('ViewName');
+    }
+
     const xmlMetaViewList = getMetaViews();
     const xmlParser = new DOMParser();
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix for resolving navigation links in card/registerViews dynamically instead of just assuming the "destination" view type.


* **What is the current behavior?** (You can also link to an open issue here)
In **cardViews** the link target view is determined straight from the entity type, which sometimes leads to "broken" links as in some cases the Card/RegisterView entity has "Economy:" before the name. The "Economy:" part is not included directly in the entity name.
In **registerViews** there is hard coded "assumption" that the link to other view is always in the first column and leads to a cardview of the same type as the register. Otherwise the same flaw mentioned above exists here as well (lack of "Economy:" might cause broken links).


* **What is the new behavior (if this is a feature change)?**
Created an utils function `resolveLinkTargetView` to correctly determine the destination view type based on the entity and command (for example. entity: "DiscountContract", command: "NavigateToCardCommand"). Based on the information the schema metaviews are iterated and checked if there exists a view that includes both, entity name and the viewType (declared in command).
To fix the registerView link creation, the registerView parsing logic was refactored to include the elementType and child node (if elementType === "Button") to correctly resolve the link later.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Add screenshot if possible.** (Add screenshot of the change)
No changes to the UI other than working links between views.


* **Other information**:
Closes #28 