### PR TITLE
Fix for ready made test cases

### DIFF
--- a/__mocks__/svg.js
+++ b/__mocks__/svg.js
@@ -1,0 +1,2 @@
+export default 'SvgrURL';
+export const ReactComponent = 'div';

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,8 +1,12 @@
 {
     "testEnvironment": "jsdom",
+    "moduleNameMapper": {
+        "\\.svg$": "<rootDir>/__mocks__/svg.js"
+    },
     "reporters": [
         "default",
-        "./node_modules/jest-html-reporter", {
+        "./node_modules/jest-html-reporter",
+        {
             "pageTitle": "Your test suite",
             "outputPath": "reports/jest-html.html",
             "includeFailureMsg": false,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Jest does not support `.svg` files to be imported. This fix allows jest to run all the ready made tests.


* **What is the current behavior?** (You can also link to an open issue here)
Jest was not able to run all the test cases because of the imported `.svg` files.


* **What is the new behavior (if this is a feature change)?**
Jest is able to run all the ready made test cases.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Add screenshot if possible.** (Add screenshot of the change)
![kuva](https://github.com/Turtiainen/assisdent-web-client-continuation/assets/120399613/0cdffadd-08be-4d39-99c7-4a0edbec789f)



* **Other information**:
This pull request closes #41 