### PR TITLE
Patient card view saving

### DIFF
--- a/src/components/View/CardView.tsx
+++ b/src/components/View/CardView.tsx
@@ -29,7 +29,7 @@ export type DataProps = {
 type saveViewModelOptionsType = {
     ViewName: string | null;
     ViewModelData: DynamicObject;
-    ArgumentType: string;
+    CardViewType: string;
 };
 
 type saveNewEntityOptionsType = {
@@ -148,7 +148,7 @@ export const CardView = ({ view }: DataProps) => {
 
         const saveViewModelOptions: saveViewModelOptionsType = {
             ViewName: viewName,
-            ArgumentType: `Edit${viewName}Argument`,
+            CardViewType: 'Edit',
             ViewModelData: {
                 Entity: {
                     ...reducedChangedValues,

--- a/src/components/View/CardView/BasicInput.tsx
+++ b/src/components/View/CardView/BasicInput.tsx
@@ -16,7 +16,7 @@ export const BasicInput = ({
     updateChangedTextInputValue: (
         valueString: string,
         key: string,
-        value: string,
+        value: string | number | boolean | null,
     ) => void;
 }) => {
     const constructValuePrintStyle = (

--- a/src/components/View/CardView/BooleanInput.tsx
+++ b/src/components/View/CardView/BooleanInput.tsx
@@ -13,7 +13,7 @@ export const BooleanInput = ({
     updateChangedTextInputValue: (
         valueString: string,
         key: string,
-        value: string | number | boolean,
+        value: string | number | boolean | null,
     ) => void;
 }) => {
     const [checked, setChecked] = useState<boolean>(

--- a/src/components/View/CardView/BooleanInput.tsx
+++ b/src/components/View/CardView/BooleanInput.tsx
@@ -2,14 +2,19 @@ import { ChangeEvent, useState } from 'react';
 import { DynamicObject } from '../../../types/DynamicObject';
 import { InputRow } from '../../InputRow';
 import { CheckboxLabeled } from '../../CheckboxLabeled';
-import { Input } from '../../Input';
 
 export const BooleanInput = ({
     element,
     content,
+    updateChangedTextInputValue,
 }: {
     element: DynamicObject;
     content: string | DynamicObject | null | undefined;
+    updateChangedTextInputValue: (
+        valueString: string,
+        key: string,
+        value: string | number | boolean,
+    ) => void;
 }) => {
     const [checked, setChecked] = useState<boolean>(
         content?.toString() === 'true',
@@ -17,7 +22,12 @@ export const BooleanInput = ({
 
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
         e.persist();
-        setChecked(!checked);
+        setChecked(e.target.checked);
+        updateChangedTextInputValue(
+            element.attributes?.Value,
+            element.attributes?.Identifier,
+            e.target.checked,
+        );
     };
     return (
         <InputRow>

--- a/src/components/View/CardView/CardCustom.tsx
+++ b/src/components/View/CardView/CardCustom.tsx
@@ -6,10 +6,16 @@ export const CardCustom = ({
     element,
     cardData,
     entityType,
+    updateChangedTextInputValue,
 }: {
     element: DynamicObject;
     cardData: DynamicObject | null;
     entityType: string | null;
+    updateChangedTextInputValue: (
+        valueString: string,
+        key: string,
+        value: string | number | boolean | null,
+    ) => void;
 }) => {
     switch (element.attributes.Type) {
         case 'CardContactMethods': {
@@ -39,6 +45,9 @@ export const CardCustom = ({
                     element={element}
                     cardData={cardData}
                     entityType={entityType}
+                    viewName={`${entityType}CardView`}
+                    elementIdentifier={element.attributes?.Identifier}
+                    updateChangedTextInputValue={updateChangedTextInputValue}
                 />
             );
         }
@@ -50,6 +59,9 @@ export const CardCustom = ({
                     element={element}
                     cardData={cardData}
                     entityType={entityType}
+                    viewName={`${entityType}CardView`}
+                    elementIdentifier={element.attributes?.Identifier}
+                    updateChangedTextInputValue={updateChangedTextInputValue}
                 />
             );
         }

--- a/src/components/View/CardView/CardElement.tsx
+++ b/src/components/View/CardView/CardElement.tsx
@@ -25,7 +25,7 @@ export const CardElement = ({
     updateChangedTextInputValue: (
         valueString: string,
         key: string,
-        value: string,
+        value: string | number,
     ) => void;
     entityType: string | null;
 }) => {
@@ -103,6 +103,7 @@ export const CardElement = ({
                     element={element}
                     content={cardDetails}
                     inputProperties={{ Values: foundCatalogSchema.Entries }}
+                    updateChangedTextInputValue={updateChangedTextInputValue}
                 />
             );
         }

--- a/src/components/View/CardView/CardElement.tsx
+++ b/src/components/View/CardView/CardElement.tsx
@@ -25,7 +25,7 @@ export const CardElement = ({
     updateChangedTextInputValue: (
         valueString: string,
         key: string,
-        value: string | number,
+        value: string | number | boolean,
     ) => void;
     entityType: string | null;
 }) => {
@@ -115,18 +115,21 @@ export const CardElement = ({
                     element={element}
                     cardData={cardData}
                     entityType={foundEntitySchema.Name}
-                    viewName={""}
-                    elementIdentifier={""}
+                    viewName={''}
+                    elementIdentifier={''}
                 />
             );
         }
     }
 
-    if (
-        inputProperties.Type === 'Boolean' ||
-        inputProperties.Type === 'boolean'
-    ) {
-        return <BooleanInput element={element} content={cardDetails} />;
+    if (inputProperties.Type?.toLowerCase() === 'boolean') {
+        return (
+            <BooleanInput
+                element={element}
+                content={cardDetails}
+                updateChangedTextInputValue={updateChangedTextInputValue}
+            />
+        );
     }
 
     if (cardDetails && inputProperties.Type === 'Date') {

--- a/src/components/View/CardView/CardElement.tsx
+++ b/src/components/View/CardView/CardElement.tsx
@@ -25,7 +25,7 @@ export const CardElement = ({
     updateChangedTextInputValue: (
         valueString: string,
         key: string,
-        value: string | number | boolean,
+        value: string | number | boolean | null,
     ) => void;
     entityType: string | null;
 }) => {
@@ -138,6 +138,7 @@ export const CardElement = ({
                 element={element}
                 content={cardDetails}
                 inputProperties={inputProperties}
+                updateChangedTextInputValue={updateChangedTextInputValue}
             />
         );
     }

--- a/src/components/View/CardView/CardElement.tsx
+++ b/src/components/View/CardView/CardElement.tsx
@@ -115,8 +115,9 @@ export const CardElement = ({
                     element={element}
                     cardData={cardData}
                     entityType={foundEntitySchema.Name}
-                    viewName={''}
-                    elementIdentifier={''}
+                    viewName={`${entityType}CardView`}
+                    elementIdentifier={element.attributes?.Identifier}
+                    updateChangedTextInputValue={updateChangedTextInputValue}
                 />
             );
         }

--- a/src/components/View/CardView/CardSearch.tsx
+++ b/src/components/View/CardView/CardSearch.tsx
@@ -14,7 +14,7 @@ export const CardSearch = ({
     cardData,
     entityType,
     viewName,
-    elementIdentifier
+    elementIdentifier,
 }: {
     element: DynamicObject;
     cardData: DynamicObject | null;
@@ -64,16 +64,15 @@ export const CardSearch = ({
     const searchParameters = {
         EntityType: entityType,
         Purpose: 'QuickSearch',
-        PurposeArgs: {
-        },
+        PurposeArgs: {},
         SearchLanguage: getUserLanguage(),
     };
 
-    if(viewName != "" && elementIdentifier != "") {
+    if (viewName != '' && elementIdentifier != '') {
         searchParameters.PurposeArgs = {
-                "ViewName": viewName,
-                "ElementIdentifier": elementIdentifier
-         }
+            ViewName: viewName,
+            ElementIdentifier: elementIdentifier,
+        };
     }
 
     const mutation = useMutation({
@@ -109,23 +108,24 @@ export const CardSearch = ({
     // Handle filtering of the options depending on user input text
     const filteredOptions = useMemo(() => {
         if (isSearchVisible) {
-        const lowercasedSearchTerm = searchTerm.toLowerCase();
-        return options.filter((option: string) =>
-            constructValuePrintStyle(option, valuePrintStyle).toLowerCase().includes(lowercasedSearchTerm)
-        );
+            const lowercasedSearchTerm = searchTerm.toLowerCase();
+            return options.filter((option: string) =>
+                constructValuePrintStyle(option, valuePrintStyle)
+                    .toLowerCase()
+                    .includes(lowercasedSearchTerm),
+            );
         } else {
-        return options;
+            return options;
         }
     }, [options, searchTerm, isSearchVisible]);
 
-    console.log(options);
     return (
         <InputRow>
-                <Label htmlFor={element.attributes.Identifier} className={value}>
-                    {element.attributes.Caption ? element.attributes.Caption : ''}
-                </Label>
+            <Label htmlFor={element.attributes.Identifier} className={value}>
+                {element.attributes.Caption ? element.attributes.Caption : ''}
+            </Label>
 
-                <div className="lg:max-w-xs w-full relative">
+            <div className="lg:max-w-xs w-full relative">
                 <Select
                     labelText={element.attributes.Caption}
                     id={element.attributes.Identifier}
@@ -135,7 +135,11 @@ export const CardSearch = ({
                     }}
                     placeholder={element.attributes.Caption}
                 >
-                    <p>{element.attributes.Identifier} {element.attributes.Caption} {element.attributes.Caption}</p>
+                    <p>
+                        {element.attributes.Identifier}{' '}
+                        {element.attributes.Caption}{' '}
+                        {element.attributes.Caption}
+                    </p>
                     {filteredOptions.map((option: DynamicObject) => (
                         <option
                             key={option.Id}
@@ -156,17 +160,25 @@ export const CardSearch = ({
                     </option>
                 </Select>
                 <div className="absolute right-0 top-0 bottom-0">
-                    <button onClick={toggleSearch} className="bg-ad-sidebar h-8"><div className="px-2 py-2 max-h-10 w-7"><img src={searchMenuImage} /></div></button>
+                    <button
+                        onClick={toggleSearch}
+                        className="bg-ad-sidebar h-8"
+                    >
+                        <div className="px-2 py-2 max-h-10 w-7">
+                            <img src={searchMenuImage} />
+                        </div>
+                    </button>
                 </div>
                 {isSearchVisible && (
-                <input className=" max-h-10 w-full border border-ad-grey-300 px-2 py-1 absolute -bottom-8 right-0"
-                    type="text"
-                    placeholder="Search"
-                    value={searchTerm}
-                    onChange={e => setSearchTerm(e.target.value)}
-                />
+                    <input
+                        className=" max-h-10 w-full border border-ad-grey-300 px-2 py-1 absolute -bottom-8 right-0"
+                        type="text"
+                        placeholder="Search"
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                    />
                 )}
-                </div>
+            </div>
         </InputRow>
     );
 };

--- a/src/components/View/CardView/CardViewBuilder.tsx
+++ b/src/components/View/CardView/CardViewBuilder.tsx
@@ -52,14 +52,14 @@ export const CardViewBuilder = ({
     const entityPropertySchema = getEntityPropertiesSchema(entityType);
 
     /*
-     * This function is called when a basic input value in the card is changed.
+     * This function is called when a basic/catalog input value in the card is changed.
      * So, it should be passed downwards to such elements
      * Not sure if it should be on this level, but this is the way it at least works for now.
      */
     const updateChangedTextInputValue = (
         valueString: string,
         key: string,
-        value: string,
+        value: string | number,
     ) => {
         // const newChangedValues = changedValues ? [...changedValues] : [];
         const newChangedValues = [...changedValues];

--- a/src/components/View/CardView/CardViewBuilder.tsx
+++ b/src/components/View/CardView/CardViewBuilder.tsx
@@ -59,7 +59,7 @@ export const CardViewBuilder = ({
     const updateChangedTextInputValue = (
         valueString: string,
         key: string,
-        value: string | number,
+        value: string | number | boolean | null,
     ) => {
         // const newChangedValues = changedValues ? [...changedValues] : [];
         const newChangedValues = [...changedValues];
@@ -128,7 +128,7 @@ export const CardViewBuilder = ({
                                 changedValues={changedValues}
                             />
                         );
-                    case 'List':
+                    case 'List': {
                         const sanitizedBinding = sanitizeBinding(
                             element.attributes.Value,
                         );
@@ -150,6 +150,7 @@ export const CardViewBuilder = ({
                                 entityType={elementTypeObject}
                             />
                         );
+                    }
                     case 'Element':
                         return (
                             <CardElement

--- a/src/components/View/CardView/CardViewBuilder.tsx
+++ b/src/components/View/CardView/CardViewBuilder.tsx
@@ -52,7 +52,7 @@ export const CardViewBuilder = ({
     const entityPropertySchema = getEntityPropertiesSchema(entityType);
 
     /*
-     * This function is called when a basic/catalog input value in the card is changed.
+     * This function is called when any input value in the card is changed (basicInput, dateInput, booleans, etc.).
      * So, it should be passed downwards to such elements
      * Not sure if it should be on this level, but this is the way it at least works for now.
      */

--- a/src/components/View/CardView/CardViewBuilder.tsx
+++ b/src/components/View/CardView/CardViewBuilder.tsx
@@ -104,7 +104,11 @@ export const CardViewBuilder = ({
             const isNewAssociation = newChangedValues.find((item) => {
                 return Object.hasOwn(item, keysArray[0]);
             });
-            if (associationType && isNewAssociation) {
+            if (
+                associationType &&
+                isNewAssociation &&
+                !newChangedValues[newChangedValues.length - 1][keysArray[0]].Id
+            ) {
                 newChangedValues[newChangedValues.length - 1][keysArray[0]].Id =
                     cardData?.Entity[keysArray[0]]?.Id;
             }

--- a/src/components/View/CardView/CardViewBuilder.tsx
+++ b/src/components/View/CardView/CardViewBuilder.tsx
@@ -127,7 +127,7 @@ export const CardViewBuilder = ({
                                 updateChangedValues={updateChangedValues}
                                 changedValues={changedValues}
                             />
-                        ); 
+                        );
                     case 'List':
                         const sanitizedBinding = sanitizeBinding(
                             element.attributes.Value,
@@ -149,7 +149,7 @@ export const CardViewBuilder = ({
                                 cardData={cardData}
                                 entityType={elementTypeObject}
                             />
-                        ); 
+                        );
                     case 'Element':
                         return (
                             <CardElement
@@ -183,11 +183,13 @@ export const CardViewBuilder = ({
                                 element={element}
                                 cardData={cardData}
                                 entityType={elementTypeObject.Type}
-                                viewName={entityType + "CardView"}
-                                elementIdentifier={element.attributes.Identifier}
+                                viewName={entityType + 'CardView'}
+                                elementIdentifier={
+                                    element.attributes.Identifier
+                                }
                             />
                         );
-                    } 
+                    }
                     case 'Button': {
                         return (
                             <CardButton
@@ -233,7 +235,7 @@ export const CardViewBuilder = ({
                                 cardData={cardData}
                                 entityType={entityType}
                             />
-                        ); 
+                        );
                     default:
                         return (
                             <p key={element.attributes['__id'] as Key}>

--- a/src/components/View/CardView/CardViewBuilder.tsx
+++ b/src/components/View/CardView/CardViewBuilder.tsx
@@ -188,6 +188,9 @@ export const CardViewBuilder = ({
                                 elementIdentifier={
                                     element.attributes.Identifier
                                 }
+                                updateChangedTextInputValue={
+                                    updateChangedTextInputValue
+                                }
                             />
                         );
                     }
@@ -235,6 +238,9 @@ export const CardViewBuilder = ({
                                 element={element}
                                 cardData={cardData}
                                 entityType={entityType}
+                                updateChangedTextInputValue={
+                                    updateChangedTextInputValue
+                                }
                             />
                         );
                     default:

--- a/src/components/View/CardView/CatalogInput.tsx
+++ b/src/components/View/CardView/CatalogInput.tsx
@@ -9,18 +9,33 @@ export const CatalogInput = ({
     element,
     content,
     inputProperties,
+    updateChangedTextInputValue,
 }: {
     element: DynamicObject;
     content: string | DynamicObject | null | undefined;
     inputProperties: DynamicObject;
+    updateChangedTextInputValue: (
+        valueString: string,
+        key: string,
+        value: string | number,
+    ) => void;
 }) => {
     const [value, setValue] = useState<string>(content?.toString() || '');
 
-    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const handleChange = (
+        e: ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+    ) => {
         e.persist();
         setValue(e.target.value);
+        // Use catalog key value as value instead of "DisplayString".
+        // Sometimes key is a number -> try converting to int.
+        const keyInt = parseInt(e.target.value);
+        updateChangedTextInputValue(
+            element.attributes?.Value,
+            element.attributes?.Identifier,
+            keyInt || e.target.value,
+        );
     };
-
     return (
         <InputRow>
             <Label htmlFor={element.attributes.Identifier} className={value}>
@@ -31,9 +46,7 @@ export const CatalogInput = ({
                     labelText={element.attributes.Caption}
                     id={element.attributes.Identifier}
                     value={value}
-                    onChange={(e) => {
-                        setValue(e.target.value);
-                    }}
+                    onChange={handleChange}
                 >
                     {inputProperties.Values.map((option: DynamicObject) => (
                         <option key={option.Key} value={option.Key}>

--- a/src/components/View/CardView/CatalogInput.tsx
+++ b/src/components/View/CardView/CatalogInput.tsx
@@ -17,7 +17,7 @@ export const CatalogInput = ({
     updateChangedTextInputValue: (
         valueString: string,
         key: string,
-        value: string | number,
+        value: string | number | boolean | null,
     ) => void;
 }) => {
     const [value, setValue] = useState<string>(content?.toString() || '');

--- a/src/components/View/CardView/DateInput.tsx
+++ b/src/components/View/CardView/DateInput.tsx
@@ -8,10 +8,16 @@ export const DateInput = ({
     element,
     content,
     inputProperties,
+    updateChangedTextInputValue,
 }: {
     element: DynamicObject;
     content: string | DynamicObject;
     inputProperties: DynamicObject;
+    updateChangedTextInputValue: (
+        valueString: string,
+        key: string,
+        value: string | number | boolean | null,
+    ) => void;
 }) => {
     // Check if date should be in format YYYY-MM or YYYY-MM-DD
     const inputType =
@@ -22,7 +28,7 @@ export const DateInput = ({
 
     // if inputType is date, then value should be content.toString().split('T')[0], otherwise only YYYY-MM
     const defaultDateValue = content.toString().split('T')[0];
-    const [value, setValue] = useState(
+    const [value, setValue] = useState<string>(
         inputType === 'date'
             ? defaultDateValue
             : defaultDateValue.split('-')[0] +
@@ -32,6 +38,12 @@ export const DateInput = ({
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
         e.persist();
         setValue(e.target.value);
+        updateChangedTextInputValue(
+            element.attributes?.Value,
+            element.attributes?.Identifier,
+            //pass in null if date field is emptied (value = "") so that the api can handle it properly
+            e.target.value || null,
+        );
     };
 
     return (

--- a/src/utils/associationUtils.ts
+++ b/src/utils/associationUtils.ts
@@ -30,7 +30,7 @@ export const mapAssociationTypeUpdatePatchCommands = (
         } else if (obj.associationType === AssociationType.Aggregation) {
             for (const [key, value] of Object.entries(obj)) {
                 if (key !== 'associationType' && key !== 'Id') {
-                    obj[key] = { _set_ref: [value] };
+                    obj[key] = { _set_ref: [{ Id: value?.Id }] };
                 }
             }
         }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Changes to cardView state handling and saving logic.


* **What is the current behavior?** (You can also link to an open issue here)
Before updates, the form state handling was only implemented to the basicInput elements (aka. text fields) and the saving functionality did not work since the payload was invalid.


* **What is the new behavior (if this is a feature change)?**
This extends the cardView form handling to all element types (that are currently implemented). Also the deprecated update payload (`saveViewModelOptionsType`) was corrected. Additionally fixed some assosiation resolving logic and the overall logic in order to create a valid patch payload.
After the changes there are still some fields that can not be updated due to either 1. backend validations or 2. some other reason.
Manual testing revealed that the following individual fields can not be updated:
  - Kuva
  - Henkilötunnus (backend validations fail / disallows change)
  - Toivutut yhteydenottotavat
  - Sisäinen/ulkoinen tunniste (backend validations fail / disallows change)
  - Laskutustiedot section as a whole (excluding boolean values)
  - gender can not be changed to "Ei tiedossa", to "Mies" or "Nainen" works though.



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.
* **Add screenshot if possible.** (Add screenshot of the change)
No visual changes


* **Other information**:
Closes #15 