### PR TITLE
Add dynamic api calling feature in backend.ts and constants.ts.

### DIFF
--- a/src/components/FieldChoice.tsx
+++ b/src/components/FieldChoice.tsx
@@ -10,7 +10,7 @@ import {
     warningIcon,
     warningIconBackground,
 } from '../styles/globalStyles';
-import { ChangeEvent, KeyboardEventHandler, useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export const FieldChoice = () => {
@@ -32,11 +32,10 @@ export const FieldChoice = () => {
         }
     };
 
-    const handleKeyPress = (e: KeyboardEventHandler<HTMLInputElement>) => {
-        console.log(e);
-        // if (e.key === 'Enter' && field !== '') {
-        //     chooseField();
-        // }
+    const handleKeyPress = (e: { code: string }) => {
+        if (e.code === 'Enter' && field !== '') {
+            chooseField();
+        }
     };
 
     return (
@@ -85,6 +84,7 @@ export const FieldChoice = () => {
                                 placeholder="Toimialue"
                                 style={inputField}
                                 onChange={handleInputChange}
+                                onKeyPress={handleKeyPress}
                                 type="text"
                                 autoCorrect="off"
                                 autoCapitalize="off"

--- a/src/components/LoginWithCredentials.tsx
+++ b/src/components/LoginWithCredentials.tsx
@@ -12,7 +12,13 @@ import {
     backgroundExtender,
 } from '../styles/globalStyles';
 import { useNavigate } from 'react-router-dom';
-import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import {
+    ChangeEvent,
+    KeyboardEventHandler,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
 import { doLogin } from '../services/backend';
 
 export const LoginWithCredentials = () => {
@@ -42,7 +48,14 @@ export const LoginWithCredentials = () => {
         const field = localStorage.getItem('domain');
         if (field === undefined || field === '' || field === null)
             emptyFieldSelection();
-    }, [emptyFieldSelection]);
+        // if (process.env.NODE_ENV === 'development') {
+        //     doLogin(
+        //         import.meta.env.VITE_ASSISCARE_USER,
+        //         import.meta.env.VITE_ASSISCARE_PASS,
+        //     );
+        //     navigate('/');
+        // }
+    }, [emptyFieldSelection, doLogin]);
 
     const handleLogin = async () => {
         if (username !== '' && username !== null && username !== undefined)
@@ -62,6 +75,13 @@ export const LoginWithCredentials = () => {
             } else setError('Please input password');
         else setError('Please input username');
     };
+
+    const handleKeyPress = (e: { code: string }) => {
+        if (e.code === 'Enter') {
+            handleLogin();
+        }
+    };
+
     return (
         <div
             className="md:container md:mx-auto flex flex-wrap content-center justify-center bg-background-ig h-3/4"
@@ -110,6 +130,7 @@ export const LoginWithCredentials = () => {
                             placeholder="Käyttäjätunnus"
                             style={inputField}
                             onChange={handleUsernameChange}
+                            onKeyPress={handleKeyPress}
                             autoCorrect="off"
                             autoCapitalize="off"
                             type="text"
@@ -124,6 +145,7 @@ export const LoginWithCredentials = () => {
                             id="password"
                             style={inputField}
                             onChange={handlePasswordChange}
+                            onKeyPress={handleKeyPress}
                             autoCorrect="off"
                             autoCapitalize="off"
                         ></input>

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -1,13 +1,7 @@
 import axios, { isAxiosError } from 'axios';
 import { DtoSchema } from '../types/DtoSchema';
 import { DynamicObject } from '../types/DynamicObject';
-import {
-    ENDPOINT_ENTITY_SEARCH,
-    ENDPOINT_LOGIN,
-    ENDPOINT_SCHEMA,
-    ENDPOINT_VIEWMODEL_GET,
-} from '../utils/constants';
-import { useNavigate } from 'react-router-dom';
+import { getUrls } from '../utils/constants';
 
 type LoginData = {
     Username: string;
@@ -48,9 +42,10 @@ export const doLogin = async (username: string, password: string) => {
         LoginType: 'Rest',
     };
 
+    console.log(localStorage.getItem('domain'));
     try {
         const { data } = await axios.post<LoginResponse>(
-            ENDPOINT_LOGIN,
+            getUrls().loginUrl,
             loginData,
         );
 
@@ -91,7 +86,7 @@ export async function getSchema() {
                 Authorization: `Bearer ${accessToken}`,
             };
 
-            const { data } = await axios.get(ENDPOINT_SCHEMA, { headers });
+            const { data } = await axios.get(getUrls().schemaUrl, { headers });
             return data as DtoSchema;
         } catch (error) {
             if (axios.isAxiosError(error)) {
@@ -118,7 +113,7 @@ export const getEntitiesForRegisterView = async (options: DynamicObject) => {
     };
 
     try {
-        const { data } = await axios.post(ENDPOINT_ENTITY_SEARCH, body, {
+        const { data } = await axios.post(getUrls().entitySearchUrl, body, {
             headers: { Authorization: `Bearer ${token}` },
         });
         return data;
@@ -143,7 +138,7 @@ export const getEntityData = async (searchOptions: DynamicObject) => {
         const body = {
             ...searchOptions,
         };
-        const { data } = await axios.post(ENDPOINT_ENTITY_SEARCH, body, {
+        const { data } = await axios.post(getUrls().entitySearchUrl, body, {
             headers: { Authorization: `Bearer ${token}` },
         });
         return data;
@@ -168,7 +163,7 @@ export const getViewModelData = async (searchOptions: DynamicObject) => {
         const body = {
             ...searchOptions,
         };
-        const { data } = await axios.post(ENDPOINT_VIEWMODEL_GET, body, {
+        const { data } = await axios.post(getUrls().viewModelGetUrl, body, {
             headers: { Authorization: `Bearer ${token}` },
         });
 
@@ -197,13 +192,9 @@ export const putEntityData = async (entityData: DynamicObject) => {
         const body = {
             ...entityData,
         };
-        const { data } = await axios.put(
-            `${import.meta.env.VITE_ASSISCARE_BASE}${
-                import.meta.env.VITE_ASSISCARE_ROUTE
-            }dack/entity`,
-            body,
-            { headers: { Authorization: `Bearer ${token}` } },
-        );
+        const { data } = await axios.put(getUrls().entityUrl, body, {
+            headers: { Authorization: `Bearer ${token}` },
+        });
         return data;
     } catch (error) {
         if (axios.isAxiosError(error)) {
@@ -224,13 +215,9 @@ export const postEntityData = async (entityData: DynamicObject) => {
         const body = {
             ...entityData,
         };
-        const { data } = await axios.post(
-            `${import.meta.env.VITE_ASSISCARE_BASE}${
-                import.meta.env.VITE_ASSISCARE_ROUTE
-            }dack/entity`,
-            body,
-            { headers: { Authorization: `Bearer ${token}` } },
-        );
+        const { data } = await axios.post(getUrls().entityUrl, body, {
+            headers: { Authorization: `Bearer ${token}` },
+        });
         return data;
     } catch (error) {
         if (axios.isAxiosError(error)) {
@@ -251,13 +238,9 @@ export const saveViewModelData = async (viewModelData: DynamicObject) => {
         const body = {
             ...viewModelData,
         };
-        const { data } = await axios.post(
-            `${import.meta.env.VITE_ASSISCARE_BASE}${
-                import.meta.env.VITE_ASSISCARE_ROUTE
-            }dack/viewmodel/save`,
-            body,
-            { headers: { Authorization: `Bearer ${token}` } },
-        );
+        const { data } = await axios.post(getUrls().viewModelSaveUrl, body, {
+            headers: { Authorization: `Bearer ${token}` },
+        });
         return data;
     } catch (error) {
         if (axios.isAxiosError(error)) {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,10 +1,29 @@
-export const BASE_ROUTE = `${import.meta.env.VITE_ASSISCARE_BASE}${
-    import.meta.env.VITE_ASSISCARE_ROUTE
-}`;
-export const ENDPOINT_LOGIN = `${BASE_ROUTE}login`;
-export const ENDPOINT_SCHEMA = `${BASE_ROUTE}dack/schema`;
-export const ENDPOINT_VIEWMODEL_GET = `${BASE_ROUTE}dack/viewmodel/get`;
-export const ENDPOINT_ENTITY_SEARCH = `${BASE_ROUTE}dack/entity/search`;
+export const getDomain = () => localStorage.getItem('domain');
+export const BASE_ROUTE = () =>
+    `${import.meta.env.VITE_ASSISCARE_BASE}` + getDomain() + '/';
+
+export enum Endpoint {
+    Login = 'login',
+    Schema = 'dack/schema',
+    ViewModelGet = 'dack/viewmodel/get',
+    ViewModelSave = 'dack/viewmodel/save',
+    EntitySearch = 'dack/entity/search',
+    Entity = 'dack/entity',
+}
+
+export const getEndpoint = (endpoint: Endpoint) => `${BASE_ROUTE()}${endpoint}`;
+
+// This feature is introduced for dynamic calling when localStorage's value change
+export const getUrls = () => {
+    return {
+        loginUrl: getEndpoint(Endpoint.Login),
+        schemaUrl: getEndpoint(Endpoint.Schema),
+        viewModelGetUrl: getEndpoint(Endpoint.ViewModelGet),
+        viewModelSaveUrl: getEndpoint(Endpoint.ViewModelSave),
+        entitySearchUrl: getEndpoint(Endpoint.EntitySearch),
+        entityUrl: getEndpoint(Endpoint.Entity),
+    };
+};
 
 export const SUPPORTED_LANGUAGES = ['fi', 'en', 'sv'] as const;
 export type SupportedLanguages = typeof SUPPORTED_LANGUAGES;


### PR DESCRIPTION
Add keyboard Enter event support in login pages.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for domain selection, all requests now support new feature: dynamic path requesting.
Enter key listener has been added to input field in login page.

* **What is the current behavior?** (You can also link to an open issue here)
As in #54 and #59 , login page don't support enter key, a manual clicking behaviour is needed to trigger login action. Also, input domain name is not included in api requests.


* **What is the new behavior (if this is a feature change)?**
Now you can use enter key to trigger login action, difference in domain name input will change everything in the system.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
All the new adding API requests need to first register in constants.ts, and use a calling stantdard like `getUrls().loginUrl` to fetch the url path dynamically.

* **Add screenshot if possible.** (Add screenshot of the change)
![CleanShot 2023-11-10 at 09 39 34](https://github.com/Turtiainen/assisdent-web-client-continuation/assets/44538391/8943870a-2fd6-4379-a175-13077b68b07b)



* **Other information**:
* Close #54 and #59 