### PR TITLE
Disable automatic deployment to vercel

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -88,7 +88,7 @@ jobs:
       - run: npm run test:coverage
       - run: npm run test:coveralls
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   #Deploy-Preview:
   #  needs: Test

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -88,7 +88,8 @@ jobs:
       - run: npm run test:coverage
       - run: npm run test:coveralls
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@master
+        if: ${{ always() }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
 
   #Deploy-Preview:
   #  needs: Test

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -86,10 +86,8 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm run test:ci
       - run: npm run test:coverage
- #     - run: npm run test:coveralls
       - name: Coveralls
         uses: coverallsapp/github-action@master
-        if: ${{ always() }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -86,7 +86,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm run test:ci
       - run: npm run test:coverage
-      - run: npm run test:coveralls
+ #     - run: npm run test:coveralls
       - name: Coveralls
         uses: coverallsapp/github-action@master
         if: ${{ always() }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -85,7 +85,7 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm run test:ci
-      - run: npm run test:coverage
+      - run: npm run test:jest:coverage
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/jest.config.json
+++ b/jest.config.json
@@ -2,15 +2,5 @@
     "testEnvironment": "jsdom",
     "moduleNameMapper": {
         "\\.svg$": "<rootDir>/__mocks__/svg.js"
-    },
-    "reporters": [
-        "default",
-        "./node_modules/jest-html-reporter",
-        {
-            "pageTitle": "Your test suite",
-            "outputPath": "reports/jest-html.html",
-            "includeFailureMsg": false,
-            "styleOverridePath": "src/teststyle.css"
-        }
-    ]
+    }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:ci": "jest --ci --reporters=default --reporters=jest-junit --reporters=jest-html-reporter",
     "test:coverage": "c8 --reporter=text --reporter=lcov --reporter=html --reporter=json npm test",
     "test:coveralls": "c8 npm test && c8 report --reporter=text-lcov | coveralls",
+    "test:jest:coverage": "jest --coverage",
     "lint": "eslint src --ext .tsx",
     "lint:fix": "eslint src --ext .tsx --fix"
   },

--- a/src/test/Util.MapUtils.test.tsx
+++ b/src/test/Util.MapUtils.test.tsx
@@ -30,6 +30,11 @@ describe('Call mapObjectPaths', () => {
         Test3: 'value3',
     };
 
+    const coverContinueBranch = {
+        Id: 'Id',
+        _Test: '_Test',
+    };
+
     const nestedObject1 = {
         Test1: 'value1',
         Test2: {
@@ -51,6 +56,11 @@ describe('Call mapObjectPaths', () => {
 
     it('should return empty array if called with empty object', () => {
         const returnValue = mapObjectPaths({});
+        expect(returnValue).toEqual([]);
+    });
+
+    it('should return empty array since Id and key that starts with _ are ignored', () => {
+        const returnValue = mapObjectPaths(coverContinueBranch);
         expect(returnValue).toEqual([]);
     });
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,7 @@
 {
+    "git": {
+        "deploymentEnabled": false
+    },
     "rewrites":  [
         {"source": "/(.*)", "destination": "/"}
     ]


### PR DESCRIPTION
This PR prevents automatic deployment to vercel and fixes small issue in running coveralls.
Changed coverage report to use Jest since c8 did not work correctly. Verified Jest coverage by covering mapUtils.ts fully.