### PR TITLE
Patient card view saving

### DIFF
--- a/src/components/View/CardView/CardViewBuilder.tsx
+++ b/src/components/View/CardView/CardViewBuilder.tsx
@@ -71,11 +71,6 @@ export const CardViewBuilder = ({
         const valueObj: DynamicObject = {};
         let currentObj = valueObj;
 
-        // FIXME Special case: PatientInvoicingAddress can not be updated currently
-        if (keysArray[0] === 'PatientInvoicingAddress') {
-            return;
-        }
-
         // Get the association type from the schema
         const propertySchemaObj = entityPropertySchema?.[keysArray[0]];
         const associationType = getAssociationType(propertySchemaObj);
@@ -105,7 +100,8 @@ export const CardViewBuilder = ({
                 return Object.hasOwn(item, keysArray[0]);
             });
             if (
-                associationType &&
+                keysArray[0] !== 'PatientInvoicingAddress' &&
+                !associationType !== null &&
                 isNewAssociation &&
                 !newChangedValues[newChangedValues.length - 1][keysArray[0]].Id
             ) {

--- a/src/components/View/CardView/CatalogInput.tsx
+++ b/src/components/View/CardView/CatalogInput.tsx
@@ -33,7 +33,7 @@ export const CatalogInput = ({
         updateChangedTextInputValue(
             element.attributes?.Value,
             element.attributes?.Identifier,
-            keyInt || e.target.value,
+            isNaN(keyInt) ? e.target.value : keyInt,
         );
     };
     return (

--- a/src/utils/associationUtils.ts
+++ b/src/utils/associationUtils.ts
@@ -24,7 +24,13 @@ export const mapAssociationTypeUpdatePatchCommands = (
         if (obj.associationType === AssociationType.Composition) {
             for (const [key, value] of Object.entries(obj)) {
                 if (key !== 'associationType' && key !== 'Id') {
-                    obj[key] = { _update: [value] };
+                    //Exception: PatientInvoicingAddress can not be updated due to some backend logic:
+                    //     -> use _create patch command to create new entity instead of update existing.
+                    const mappedValue =
+                        key === 'PatientInvoicingAddress'
+                            ? { _create: [value] }
+                            : { _update: [value] };
+                    obj[key] = mappedValue;
                 }
             }
         } else if (obj.associationType === AssociationType.Aggregation) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - Fix saving functionality of remaining fields in PatientViewCard where possible.


* **What is the current behavior?** (You can also link to an open issue here)
  - Some fields can not be saved due to backend validations, missing input options or some other small errors such as "0" is sent when backend expects integer. 
  - Breakthrough of the fields that can not be edited can be seen from the other information section.
  
* **What is the new behavior (if this is a feature change)?**
  - Fields where reason was "When choosing default option, "0" is sent and backend expects 0" can not be updated correctly.
  - Laskutustiedot section (Katuosoite, postinumero, kaupunki, kunta, maa) can be changed, but not directly updated. No way to update a single attribute, all of them must be changed in order to save. There's something happening in the backend which prevets `_update` patch command, so `_create` must be used instead.
  - There are still few fields that can not be updated but that is not fixable in our end, at least currently. Fields that can not be edited are listed in the other information section


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
 - No
* **Add screenshot if possible.** (Add screenshot of the change)



* **Other information**:

| Form section | Field | Error | Fixed |
|---|---|---|---|
| General patient info | Kuva | No options to choose from, no way to upload a new image | [  ] |
|  | Henkilötunnus | Backend prevents update of this field. Validation for patient failed. The legal SSN cannot be cleared or changed via the REST interface. The change must be made using the AssisDent client. | [  ] |
|  | Sukupuoli | When choosing default option, "0" is sent and backend expects 0 | [ x ] |
|  | Sisäinen tunniste | Can not be edited in windows client either | [ ] |
| Asiakastiedot | Kutsulupa | When choosing default option, "0" is sent and backend expects 0 | [ x ] |
|  | Toivotut yhteydenottotavat | No options to choose from | [ ] |
|  | Ajanvarausten muistutusviestit | When choosing default option, "0" is sent and backend expects 0 | [ x ] |
|  | Potilaskohtaiset muistutukset | No options to choose from | [ ] |
| Laskutustiedot | Katuosoite, postinumero, kaupunki, kunta, maa | This is a entity which has a composition association to the patient, it can not be updated due to some backend logic. | [partially] |
|  | Alennus | No options to choose from | [ ] |
|  | Etukortin tyyppi | Can not be changed to K-plussa kortti, backend prevents change | [ ] |
|  | Etukortin numero | Can not be updated if etukortin tyyppi is "K-plussa kortti", backend prevents change | [ ] |
|  | Kelakorvaus | When choosing default option, "0" is sent and backend expects 0 | [ x ] |
| Luvat ja suostumukset | Terveystietojen jako organisaation sisällä | When choosing default option, "0" is sent and backend expects 0 | [ x ] |
|  | Asiakkuus | When choosing default option, "0" is sent and backend expects 0 | [ x ] |