### PR TITLE
Quick side bar fixes

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -37,7 +37,8 @@ export const Sidebar = () => {
             onClick: () =>
                 setSubSidebar(
                     subSidebar ? null : (
-                        <Menu onClick={() => setSubSidebar(null)} />)
+                        <Menu onClick={() => setSubSidebar(null)} />
+                    ),
                 ),
             isExpanded: isExpanded,
         },
@@ -104,8 +105,9 @@ export const Sidebar = () => {
     return (
         <>
             <aside
-                className={`min-h-[100vh] max-h-screen bg-ad-sidebar overflow-x-hidden overflow-y-auto transition-[width] sticky relative left-0 bottom-0 top-0 ${isExpanded ? 'w-64' : 'w-14'
-                    }`}
+                className={`min-h-[100vh] max-h-screen bg-ad-sidebar overflow-x-hidden overflow-y-auto transition-[width] sticky relative left-0 bottom-0 top-0 ${
+                    isExpanded ? 'w-64' : 'w-14'
+                }`}
             >
                 <div className="flex">
                     {isExpanded ? (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import { SidebarItems } from './SidebarItems';
 import { SidebarFooter } from './SidebarFooter';
@@ -27,19 +27,18 @@ const date = today.getDate();
 const weekday = ['Sun', 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat'];
 
 export const Sidebar = () => {
-    const [isExpanded, setIsExpanded] = useState<boolean>(false);
+    const [isExpanded, setIsExpanded] = useState<boolean>(true);
     const [subSidebar, setSubSidebar] = useState<null | JSX.Element>(null);
-
-    useEffect(() => {
-        setIsExpanded(!isExpanded);
-    }, [subSidebar]);
 
     const exampleSidebarItems = [
         {
             text: 'Valikko',
             icon: menuMenuImage,
             onClick: () =>
-                setSubSidebar(<Menu onClick={() => setSubSidebar(null)} />),
+                setSubSidebar(
+                    subSidebar ? null : (
+                        <Menu onClick={() => setSubSidebar(null)} />)
+                ),
             isExpanded: isExpanded,
         },
         {
@@ -105,9 +104,8 @@ export const Sidebar = () => {
     return (
         <>
             <aside
-                className={`min-h-[100vh] max-h-screen bg-ad-sidebar overflow-x-hidden overflow-y-auto transition-[width] sticky relative left-0 bottom-0 top-0 ${
-                    isExpanded ? 'w-64' : 'w-14'
-                }`}
+                className={`min-h-[100vh] max-h-screen bg-ad-sidebar overflow-x-hidden overflow-y-auto transition-[width] sticky relative left-0 bottom-0 top-0 ${isExpanded ? 'w-64' : 'w-14'
+                    }`}
             >
                 <div className="flex">
                     {isExpanded ? (


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
* This PR fixes annoying bug (force closing menu) when opening 'valikko' or 'haku'. Also added the ability to double click 'valikko' to open and close it.



* **What is the current behavior?** (You can also link to an open issue here)
* When you open 'valikko' or 'haku' the menu closes automatically. Clicking 'valikko' again doesn't close the 'valikko'.


* **What is the new behavior (if this is a feature change)?**
* Clicking 'valikko' or 'haku' doesn't force close menu. Also you can close 'valikko' with clicking the button again.